### PR TITLE
chore(deps): update Java backend dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,24 +6,28 @@
     <version>1.0.17</version>
 
     <properties>
-        <compiler-plugin.version>3.14.0</compiler-plugin.version>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.20.2</quarkus.platform.version>
+        <!-- Pinned to 3.36.x: Quarkus 3.37.0 removed the deprecated
+             ReflectiveClassBuildItem(boolean, boolean, Class...) constructor that
+             io.quarkiverse.jooq:quarkus-jooq 2.1.0 (latest release) still calls,
+             which makes the augmentation step fail on 3.37+. -->
+        <quarkus.platform.version>3.36.3</quarkus.platform.version>
         <skipITs>true</skipITs>
-        <surefire-plugin.version>3.5.3</surefire-plugin.version>
-        <flywayMavenPlugin.version>11.10.4</flywayMavenPlugin.version>
+        <surefire-plugin.version>3.5.6</surefire-plugin.version>
+        <flywayMavenPlugin.version>13.2.0</flywayMavenPlugin.version>
         <groovyMavenPluginVersion>2.1.1</groovyMavenPluginVersion>
         <buildHelperPlugin.version>3.6.1</buildHelperPlugin.version>
-        <jooq.version>3.20.4</jooq.version>
+        <jooq.version>3.21.7</jooq.version>
         <quarkus.jooq.version>2.1.0</quarkus.jooq.version>
-        <java-typst.version>1.4.0</java-typst.version>
-        <lombok.version>1.18.38</lombok.version>
-        <bouncycastle.version>1.81</bouncycastle.version>
-        <java-jwt.version>4.5.0</java-jwt.version>
+        <java-typst.version>2.2.0</java-typst.version>
+        <lombok.version>1.18.46</lombok.version>
+        <bouncycastle.version>1.85.2</bouncycastle.version>
+        <java-jwt.version>4.6.0</java-jwt.version>
         <javatuples.version>1.2</javatuples.version>
 
         <postgresContainerVersion>postgres:17.3-alpine</postgresContainerVersion>
@@ -257,7 +261,7 @@
                 </property>
             </activation>
             <properties>
-                <testcontainers.version>1.21.3</testcontainers.version>
+                <testcontainers.version>1.21.4</testcontainers.version>
             </properties>
             <build>
                 <plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ quarkus.datasource.jdbc.max-size=16
 quarkus.flyway.migrate-at-start=true
 
 # Quarkus CORS
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://127.0.0.1:5173,http://localhost:5173
 quarkus.http.cors.headers=accept, origin, authorization, content-type, x-requested-with
 quarkus.http.cors.methods=GET,POST,PATCH,DELETE,OPTIONS


### PR DESCRIPTION
Updates all Java backend dependencies and Maven build plugins to their latest stable releases.

## Updated

| Dependency | From | To |
|---|---|---|
| Quarkus platform (`quarkus-bom`) | 3.20.2 | **3.36.3** |
| jOOQ (`jooq`, `jooq-meta`, `jooq-codegen-maven`) | 3.20.4 | 3.21.7 |
| java-typst | 1.4.0 | **2.2.0** |
| Lombok | 1.18.38 | 1.18.46 |
| Bouncy Castle (`bcprov-jdk18on`) | 1.81 | 1.85.2 |
| java-jwt | 4.5.0 | 4.6.0 |
| Flyway Maven plugin (+ `flyway-database-postgresql`) | 11.10.4 | **13.2.0** |
| Testcontainers (jOOQ codegen profile) | 1.21.3 | 1.21.4 |
| maven-compiler-plugin | 3.14.0 | 3.15.0 |
| maven-surefire-plugin / maven-failsafe-plugin | 3.5.3 | 3.5.6 |

Everything managed by the Quarkus BOM (Jackson, Netty, Hibernate Validator, RESTEasy Reactive, …) moves with the platform bump.

## Deliberately not updated

- **Quarkus 3.38.1** — pinned to 3.36.3 instead. Quarkus 3.37.0 removed the deprecated `ReflectiveClassBuildItem(boolean, boolean, Class...)` constructor that `io.quarkiverse.jooq:quarkus-jooq` 2.1.0 (its latest release, built against Quarkus 3.15.1) still calls. On 3.37+ the build fails during augmentation with `NoSuchMethodError` in `JooqProcessor#build`. 3.36.3 is the newest version that works. A comment in `pom.xml` records the constraint, and Backlog task `roomie-2` tracks unblocking it.
- **maven-compiler-plugin 4.0.0-beta-4** — beta, and requires Maven 4.
- **maven-surefire/failsafe 3.6.0-M1** — milestone release.
- **jakarta.persistence-api 4.0.0-M6** — milestone; 3.2.0 is the right level for Jakarta EE 11 / Quarkus 3.x.

## Behaviour fix included

Quarkus no longer recognises the legacy `quarkus.http.cors` key — it warns `Unrecognized configuration key` and ignores it. Left alone, the upgrade would have **silently disabled CORS**, breaking the local frontend at `:5173`. Renamed to `quarkus.http.cors.enabled`. Verified the warning is present on 3.36.3 with the old key and absent on 3.20.2, so this is genuinely introduced by the upgrade rather than pre-existing.

## Verification

All run on Temurin 21 (the repo does not build on this machine's default JDK 25):

- `./mvnw -Djooq clean package` — **BUILD SUCCESS**, including jOOQ code generation against a Testcontainers Postgres, Quarkus augmentation, and the container image build.
- No `Unrecognized configuration key` warnings remain.
- **Runtime smoke test** — booted `target/quarkus-app/quarkus-run.jar` against a throwaway Postgres 17.3. App starts on Quarkus 3.36.3, all 14 Flyway migrations apply cleanly, and `/q/health` reports `UP`.
- **java-typst 2.x** — this is a major bump that swaps the JNI native library for a WASM engine, so it was exercised directly: `JavaTypst.render(String)` still returns `byte[]` (same signature the three renderers call) and produces a valid 9 KB `%PDF-` document.

The repo has no test sources, so `mvn test` reports "No tests to run" — the smoke tests above stand in for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
